### PR TITLE
chore(ai-sdk-plugin): update mcp dependency to 1.3.10

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
       "name": "@youdotcom-oss/ai-sdk-plugin",
       "version": "0.1.0",
       "dependencies": {
-        "@youdotcom-oss/mcp": "1.3.9",
+        "@youdotcom-oss/mcp": "1.3.10",
       },
       "devDependencies": {
         "@ai-sdk/anthropic": "^2.0.56",
@@ -1004,8 +1004,6 @@
     "@radix-ui/react-select/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
-
-    "@youdotcom-oss/ai-sdk-plugin/@youdotcom-oss/mcp": ["@youdotcom-oss/mcp@1.3.9", "", { "dependencies": { "@hono/mcp": "^0.2.2", "@modelcontextprotocol/sdk": "^1.24.3", "hono": "^4.11.1", "zod": "^4.2.0" }, "bin": { "mcp": "bin/stdio.js" } }, "sha512-Qwt8SsBrjqtRYKh3gbKhjcXQlUI2VL+QQPuowjgCkenk6HiGTJH/cUP7YY1Jd3lbZwGineEkQvoKxyHQeFvWcQ=="],
 
     "caller-callsite/callsites": ["callsites@2.0.0", "", {}, "sha512-ksWePWBloaWPxJYQ8TL0JHvtci6G5QTKwQ95RcWAa/lzoAKuAOflGdAK92hpHXjkwb8zLxoLNUoNYZgVsaJzvQ=="],
 

--- a/packages/ai-sdk-plugin/package.json
+++ b/packages/ai-sdk-plugin/package.json
@@ -69,7 +69,7 @@
   },
   "types": "./dist/main.d.ts",
   "dependencies": {
-    "@youdotcom-oss/mcp": "1.3.9"
+    "@youdotcom-oss/mcp": "1.3.10"
   },
   "peerDependencies": {
     "ai": "^5.0.0"


### PR DESCRIPTION
## Summary

Updates the `@youdotcom-oss/mcp` dependency from version `1.3.9` to `1.3.10` in the AI SDK Plugin package.

## Changes

- Updated `@youdotcom-oss/mcp` dependency from 1.3.9 to 1.3.10 in `packages/ai-sdk-plugin/package.json`
- Updated `bun.lock` to reflect the new dependency version
- Verified all quality checks pass (biome, TypeScript, package format)

## Testing

- ✅ Ran `bun run check` - all checks passed
- ✅ TypeScript compilation successful
- ✅ Code formatting and linting validated

## Related Issue

Closes #16

## Checklist

- [x] Review release notes and changes
- [x] Update package.json with new version (exact version, no `^` or `~`)
- [x] Run quality checks for dependent package
- [x] Update lockfile with `bun install`