### PR TITLE
DX-242: remove language search operator

### DIFF
--- a/packages/api/src/search/search.schemas.ts
+++ b/packages/api/src/search/search.schemas.ts
@@ -1,7 +1,10 @@
 import * as z from 'zod'
 
 export const SearchQuerySchema = z.object({
-  query: z.string().min(1, 'Query is required').describe('Search query (supports +, -, site:, filetype:, lang:)'),
+  query: z
+    .string()
+    .min(1, 'Query is required')
+    .describe('Search query (supports +, -, site:, filetype:, AND, OR, NOT)'),
   count: z.number().int().min(1).max(100).optional().describe('Max results per section'),
   freshness: z.string().optional().describe('day/week/month/year or YYYY-MM-DDtoYYYY-MM-DD'),
   offset: z.number().int().min(0).max(9).optional().describe('Pagination offset'),

--- a/packages/api/src/search/search.utils.ts
+++ b/packages/api/src/search/search.utils.ts
@@ -5,7 +5,7 @@ import { type SearchQuery, SearchResponseSchema } from './search.schemas.ts'
 
 export const fetchSearchResults = async ({
   YDC_API_KEY = process.env.YDC_API_KEY,
-  searchQuery: { query, site, fileType, language, exactTerms, excludeTerms, ...rest },
+  searchQuery: { query, site, fileType, exactTerms, excludeTerms, ...rest },
   getUserAgent,
 }: {
   searchQuery: SearchQuery
@@ -16,11 +16,10 @@ export const fetchSearchResults = async ({
 
   const searchParams = new URLSearchParams()
 
-  // Build Query Param
+  // Build Query Param with search operators
   const searchQuery = [query]
   site && searchQuery.push(`site:${site}`)
   fileType && searchQuery.push(`filetype:${fileType}`)
-  language && searchQuery.push(`lang:${language}`)
   if (exactTerms && excludeTerms) {
     throw new Error('Cannot specify both exactTerms and excludeTerms - please use only one')
   }


### PR DESCRIPTION
Removed language search operator as it's a query param per https://docs.you.com/search/search-operators and https://docs.you.com/api-reference/search/v1-search