### PR TITLE
fix(mcp): return 405 for unsupported HTTP methods per MCP spec

### DIFF
--- a/packages/mcp/src/http.ts
+++ b/packages/mcp/src/http.ts
@@ -52,6 +52,20 @@ const handleMcpRequest = async (c: Context) => {
   return response
 }
 
+const return405MethodNotAllowed = (c: Context) => {
+  c.status(405)
+  c.header('Allow', 'POST')
+  c.header('Content-Type', 'application/json')
+  return c.json({
+    jsonrpc: '2.0',
+    error: {
+      code: -32000,
+      message: 'Method Not Allowed: Use POST to send MCP requests',
+    },
+    id: null,
+  })
+}
+
 const app = new Hono()
 app.use(trimTrailingSlash())
 
@@ -64,7 +78,14 @@ app.get('/mcp-health', async (c) => {
   })
 })
 
-app.all('/mcp', handleMcpRequest)
-app.all('/mcp/', handleMcpRequest)
+// POST handler for MCP requests (per MCP Streamable HTTP spec)
+app.post('/mcp', handleMcpRequest)
+app.post('/mcp/', handleMcpRequest)
+
+// Fallback for other methods - returns 405 per MCP spec
+// Spec: "The server MUST either return Content-Type: text/event-stream
+// or else return HTTP 405 Method Not Allowed"
+app.all('/mcp', return405MethodNotAllowed)
+app.all('/mcp/', return405MethodNotAllowed)
 
 export default app

--- a/packages/mcp/src/tests/http.spec.ts
+++ b/packages/mcp/src/tests/http.spec.ts
@@ -1,11 +1,15 @@
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import httpApp from '../http.ts'
+import type { SearchStructuredContent } from '../search/search.schema.ts'
 
 // Increase default timeout for hooks to prevent intermittent failures
 setDefaultTimeout(15_000)
 
 let server: ReturnType<typeof Bun.serve>
 let baseUrl: string
+let mcpClient: Client
 const testApiKey = process.env.YDC_API_KEY
 
 beforeAll(async () => {
@@ -21,9 +25,29 @@ beforeAll(async () => {
 
   // Wait a bit for server to start
   await new Promise((resolve) => setTimeout(resolve, 500))
+
+  // Create MCP client with HTTP transport for e2e testing
+  const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+      },
+    },
+  })
+
+  mcpClient = new Client({
+    name: 'test-http-client',
+    version: '1.0.0',
+  })
+
+  await mcpClient.connect(transport)
 })
 
 afterAll(async () => {
+  if (mcpClient) {
+    await mcpClient.close()
+  }
+
   if (server) {
     server.stop()
     // Wait a bit for server to fully stop
@@ -168,6 +192,75 @@ describe('HTTP Server Endpoints', () => {
 
     const text = await response.text()
     expect(text).toBe('Unauthorized: Authorization header required')
+  })
+})
+
+describe('HTTP Method Handling', () => {
+  test('mcp endpoint returns 405 for GET requests per MCP spec', async () => {
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+        Authorization: `Bearer ${testApiKey}`,
+      },
+    })
+
+    // Verify 405 status
+    expect(response.status).toBe(405)
+
+    // Verify Allow header (RFC 9110 §15.5.6)
+    expect(response.headers.get('allow')).toBe('POST')
+
+    // Verify JSON-RPC error format
+    expect(response.headers.get('content-type')).toContain('application/json')
+
+    const data = (await response.json()) as {
+      jsonrpc: string
+      error: { code: number; message: string }
+      id: null
+    }
+    expect(data).toHaveProperty('jsonrpc', '2.0')
+    expect(data).toHaveProperty('error')
+    expect(data.error).toHaveProperty('code', -32000)
+    expect(data.error.message).toContain('Method Not Allowed')
+  })
+
+  test('mcp endpoint returns 405 for DELETE requests', async () => {
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: `Bearer ${testApiKey}`,
+      },
+    })
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('POST')
+  })
+
+  test('mcp endpoint returns 405 for PUT requests', async () => {
+    const response = await fetch(`${baseUrl}/mcp`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${testApiKey}`,
+      },
+      body: JSON.stringify({}),
+    })
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('POST')
+  })
+
+  test('mcp endpoint with trailing slash returns 405 for GET', async () => {
+    const response = await fetch(`${baseUrl}/mcp/`, {
+      method: 'GET',
+      headers: {
+        Accept: 'text/event-stream',
+      },
+    })
+
+    expect(response.status).toBe(405)
+    expect(response.headers.get('allow')).toBe('POST')
   })
 })
 
@@ -319,4 +412,141 @@ describe('HTTP MCP Endpoint Basic Functionality', () => {
     },
     { retry: 2 },
   )
+})
+
+describe('HTTP MCP Client E2E Tests', () => {
+  test('mcp client can initialize and list tools', async () => {
+    const tools = await mcpClient.listTools()
+
+    expect(tools.tools).toBeDefined()
+    expect(Array.isArray(tools.tools)).toBe(true)
+    expect(tools.tools.length).toBeGreaterThan(0)
+
+    // Verify search tool is available
+    const searchTool = tools.tools.find((t) => t.name === 'you-search')
+    expect(searchTool).toBeDefined()
+    expect(searchTool?.title).toBe('Web Search')
+
+    // Verify contents tool is available
+    const contentsTool = tools.tools.find((t) => t.name === 'you-contents')
+    expect(contentsTool).toBeDefined()
+    expect(contentsTool?.title).toBe('Extract Web Page Contents')
+  })
+
+  test(
+    'mcp client can call search tool successfully',
+    async () => {
+      const result = await mcpClient.callTool({
+        name: 'you-search',
+        arguments: {
+          query: 'typescript tutorial',
+          count: 2,
+        },
+      })
+
+      expect(result).toHaveProperty('content')
+      expect(result).toHaveProperty('structuredContent')
+
+      const content = result.content as { type: string; text: string }[]
+      expect(Array.isArray(content)).toBe(true)
+      expect(content[0]).toHaveProperty('type', 'text')
+      expect(content[0]).toHaveProperty('text')
+
+      const text = content[0]?.text
+      expect(text).toContain('Search Results for')
+      expect(text).toContain('typescript tutorial')
+
+      const structuredContent = result.structuredContent as SearchStructuredContent
+      expect(structuredContent).toHaveProperty('resultCounts')
+      expect(structuredContent.resultCounts).toHaveProperty('web')
+      expect(structuredContent.resultCounts).toHaveProperty('total')
+    },
+    { retry: 2 },
+  )
+
+  test(
+    'mcp client handles search with multiple results',
+    async () => {
+      const result = await mcpClient.callTool({
+        name: 'you-search',
+        arguments: {
+          query: 'javascript frameworks',
+          count: 3,
+        },
+      })
+
+      const content = result.content as { type: string; text: string }[]
+      const text = content[0]?.text
+
+      expect(text).toContain('WEB RESULTS:')
+      expect(text).toContain('Title:')
+      expect(text).toContain('URL:')
+
+      const structuredContent = result.structuredContent as SearchStructuredContent
+      expect(structuredContent.resultCounts.web).toBeGreaterThan(0)
+      expect(structuredContent.results?.web).toBeDefined()
+      expect(structuredContent.results?.web?.length).toBeGreaterThanOrEqual(1)
+    },
+    { retry: 2 },
+  )
+
+  test(
+    'mcp client handles search parameters correctly',
+    async () => {
+      const result = await mcpClient.callTool({
+        name: 'you-search',
+        arguments: {
+          query: 'programming tutorials',
+          count: 2,
+          safesearch: 'strict',
+          freshness: 'month',
+        },
+      })
+
+      const content = result.content as { type: string; text: string }[]
+      expect(content[0]?.text).toContain('programming tutorials')
+
+      const structuredContent = result.structuredContent as SearchStructuredContent
+      expect(structuredContent).toHaveProperty('resultCounts')
+    },
+    { retry: 2 },
+  )
+
+  test('mcp client maintains connection across multiple requests', async () => {
+    // First request
+    const result1 = await mcpClient.callTool({
+      name: 'you-search',
+      arguments: {
+        query: 'test query 1',
+        count: 1,
+      },
+    })
+
+    expect(result1).toHaveProperty('content')
+
+    // Second request - should work without reconnecting
+    const result2 = await mcpClient.callTool({
+      name: 'you-search',
+      arguments: {
+        query: 'test query 2',
+        count: 1,
+      },
+    })
+
+    expect(result2).toHaveProperty('content')
+
+    // Both should have succeeded
+    const content1 = result1.content as { type: string; text: string }[]
+    const content2 = result2.content as { type: string; text: string }[]
+
+    expect(content1[0]?.text).toContain('test query 1')
+    expect(content2[0]?.text).toContain('test query 2')
+  })
+
+  test('mcp client can list server capabilities', async () => {
+    // The client should have received server info during initialization
+    // We can verify this by checking that tools are available
+    const tools = await mcpClient.listTools()
+    expect(tools.tools.length).toBeGreaterThan(0)
+  })
 })


### PR DESCRIPTION
## Summary
Fixes #DX-252 - Updates MCP server to return proper 405 Method Not Allowed responses instead of 505 Bad Gateway when clients send unsupported HTTP methods (GET, DELETE, PUT, etc.).

## Changes

### HTTP Method Handling
- **Before**: `app.all('/mcp', ...)` accepted all HTTP methods, returning 505 for GET requests
- **After**: 
  - `app.post('/mcp', ...)` handles MCP requests (POST only)
  - `app.all('/mcp', ...)` fallback returns 405 for other methods
  - Includes required `Allow: POST` header per RFC 9110 §15.5.6
  - Returns proper JSON-RPC error format

### Test Improvements
- **4 new tests** for 405 responses (GET, DELETE, PUT, trailing slash)
- **6 new e2e tests** using MCP Client with StreamableHTTPClientTransport
- Validates full MCP protocol stack over HTTP (not just fetch-based testing)
- **100% test pass rate** (21/21 tests passing)

## MCP Spec Compliance

Per [MCP Streamable HTTP specification](https://modelcontextprotocol.io/specification/draft/basic/transports):

> "The server MUST either return `Content-Type: text/event-stream` in response to this HTTP GET, or else return HTTP 405 Method Not Allowed, indicating that the server does not offer an SSE stream at this endpoint."

This stateless server:
- ✅ Supports POST for JSON-RPC messages (required)
- ❌ Does not support GET for standalone SSE streams (optional)
- ❌ Does not support DELETE for session termination (N/A - stateless)

## Response Format

```json
HTTP/1.1 405 Method Not Allowed
Content-Type: application/json
Allow: POST

{
  "jsonrpc": "2.0",
  "error": {
    "code": -32000,
    "message": "Method Not Allowed: Use POST to send MCP requests"
  },
  "id": null
}
```

## Testing

```bash
# All checks passing
bun run check        # ✅ Biome + TypeScript + package format
bun test packages/mcp/src/tests/http.spec.ts  # ✅ 21/21 tests pass

# Manual verification
curl -i -X GET http://localhost:3000/mcp
# Returns: HTTP/1.1 405 Method Not Allowed
```

## Test Plan
- [x] All existing tests continue to pass
- [x] New 405 tests validate spec compliance
- [x] E2E tests validate MCP Client over HTTP
- [x] Code quality checks pass (Biome + TypeScript)
- [x] Manual testing with curl confirms 405 responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)