### PR TITLE
DX-256: add author email for n8n official validation

### DIFF
--- a/packages/n8n-nodes-youdotcom/package.json
+++ b/packages/n8n-nodes-youdotcom/package.json
@@ -18,6 +18,7 @@
   "homepage": "https://github.com/youdotcom-oss/dx-toolkit/tree/main/packages/n8n-nodes-youdotcom#readme",
   "author": {
     "name": "You.com",
+    "email": "tyler@you.com",
     "url": "https://you.com"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

- Add `email` field to the `author` object in the n8n node `package.json`
- Required by n8n's official community node validation process, which checks for an author email

## Linear

[DX-256](https://linear.app/you/issue/DX-256/add-author-email-to-n8n-node-packagejson-for-official-validation)