### PR TITLE
DX-257: move zod to runtime dependencies and externalize in n8n build

### DIFF
--- a/packages/n8n-nodes-youdotcom/package.json
+++ b/packages/n8n-nodes-youdotcom/package.json
@@ -46,7 +46,7 @@
   "scripts": {
     "build": "bun run build:js && bun run build:assets",
     "build:assets": "cp nodes/YouDotCom/youdotcom.svg dist/nodes/YouDotCom/ && cp nodes/YouDotCom/YouDotCom.node.json dist/nodes/YouDotCom/ && cp nodes/YouDotCom/youdotcom.svg dist/credentials/",
-    "build:js": "bun build ./nodes/YouDotCom/YouDotCom.node.ts --outfile ./dist/nodes/YouDotCom/YouDotCom.node.js --target=node --format cjs --external n8n-workflow && bun build ./credentials/YouDotComApi.credentials.ts --outfile ./dist/credentials/YouDotComApi.credentials.js --target=node --format cjs --external n8n-workflow",
+    "build:js": "bun build ./nodes/YouDotCom/YouDotCom.node.ts --outfile ./dist/nodes/YouDotCom/YouDotCom.node.js --target=node --format cjs --external n8n-workflow --external zod && bun build ./credentials/YouDotComApi.credentials.ts --outfile ./dist/credentials/YouDotComApi.credentials.js --target=node --format cjs --external n8n-workflow --external zod",
     "check": "bun run check:biome && bun run check:types && bun run check:package",
     "check:biome": "biome check",
     "check:package": "format-package --check",
@@ -64,12 +64,14 @@
       "dist/nodes/YouDotCom/YouDotCom.node.js"
     ]
   },
+  "dependencies": {
+    "zod": "^4.3.6"
+  },
   "peerDependencies": {
     "n8n-workflow": "^2.6.0"
   },
   "devDependencies": {
     "@n8n/node-cli": "^0.19.0",
-    "n8n-workflow": "^2.6.0",
-    "zod": "^4.3.6"
+    "n8n-workflow": "^2.6.0"
   }
 }


### PR DESCRIPTION
## Summary
- Move `zod` from `devDependencies` to `dependencies` so it's available at runtime when the n8n node is installed
- Add `--external zod` to the `build:js` script to prevent bundling zod into the output (resolved from `node_modules` at runtime instead)

## Context

The n8n community package security scan (`@n8n/scan-community-package`) was failing because bundling zod inlined `globalThis` references into the built output, which violates n8n's `no-restricted-globals` ESLint rule:

```
npx @n8n/scan-community-package '@youdotcom-oss/n8n-nodes-youdotcom'

❌ Package @youdotcom-oss/n8n-nodes-youdotcom@0.2.2 has failed security checks
Reason: ESLint violations found

  9815:7   error  Use of restricted global 'globalThis' is not allowed  @n8n/community-nodes/no-restricted-globals
  9816:22  error  Use of restricted global 'globalThis' is not allowed  @n8n/community-nodes/no-restricted-globals
```

By externalizing zod (so it's resolved from `node_modules` at runtime rather than bundled), the `globalThis` references from zod internals are no longer present in the built output.

Closes DX-257

I verified this against the lint rules present in the n8n community node
