### PR TITLE
fix(n8n): enable strict mode and cloud verification support

### DIFF
--- a/packages/n8n-nodes-youdotcom/biome.json
+++ b/packages/n8n-nodes-youdotcom/biome.json
@@ -1,4 +1,7 @@
 {
   "root": false,
-  "extends": "//"
+  "extends": "//",
+  "files": {
+    "includes": ["**/*.ts", "**/*.json", "**/*.md"]
+  }
 }

--- a/packages/n8n-nodes-youdotcom/eslint.config.mjs
+++ b/packages/n8n-nodes-youdotcom/eslint.config.mjs
@@ -1,3 +1,3 @@
-import { config } from '@n8n/node-cli/eslint'
+import { config } from '@n8n/node-cli/eslint';
 
-export default [{ ignores: ['**/tests/**', '**/*.test.ts', '**/*.spec.ts'] }, ...config]
+export default config;

--- a/packages/n8n-nodes-youdotcom/package.json
+++ b/packages/n8n-nodes-youdotcom/package.json
@@ -38,7 +38,7 @@
   ],
   "type": "commonjs",
   "files": [
-    "dist/**"
+    "dist"
   ],
   "publishConfig": {
     "access": "public"
@@ -56,6 +56,7 @@
   },
   "n8n": {
     "n8nNodesApiVersion": 1,
+    "strict": true,
     "credentials": [
       "dist/credentials/YouDotComApi.credentials.js"
     ],

--- a/packages/n8n-nodes-youdotcom/tests/node.test.ts
+++ b/packages/n8n-nodes-youdotcom/tests/node.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, test } from 'bun:test'
 import type { INodePropertyOptions } from 'n8n-workflow'
-import { YouDotComApi } from '../../../credentials/YouDotComApi.credentials.ts'
-import { YouDotCom } from '../YouDotCom.node.ts'
+import { YouDotComApi } from '../credentials/YouDotComApi.credentials.ts'
+import { YouDotCom } from '../nodes/YouDotCom/YouDotCom.node.ts'
 
 /**
  * Unit tests for n8n YouDotCom node


### PR DESCRIPTION
## Summary
- Adds `"strict": true` to n8n config — `n8n-node cloud-support` now shows **ENABLED** (was showing NOT eligible)
- Uses exact default `eslint.config.mjs` from `@n8n/node-cli` template (required by n8n's strict mode verification check)
- Changes `files` from `"dist/**"` to `"dist"` to match the [n8n-nodes-starter](https://github.com/n8n-io/n8n-nodes-starter) convention
- Moves tests from `nodes/YouDotCom/tests/` to `tests/` at package root so n8n's default eslint config (which lints all `**/*.ts`) doesn't flag `bun:test` imports
- Adds explicit `files.includes` in biome.json to scope biome to `.ts`, `.json`, and `.md` files — this naturally excludes `eslint.config.mjs` (a `.mjs` file) which must use n8n's semicolon style rather than our project style

## Context
n8n's verification team reported "Can't find credential file in repo". Investigation against the [n8n-nodes-starter](https://github.com/n8n-io/n8n-nodes-starter) revealed two issues:
1. Missing `"strict": true` — n8n's `cloud-support` check was reporting the package as **not eligible** for Cloud verification
2. Custom `eslint.config.mjs` (with test ignores) didn't match the expected default config, which strict mode validates character-for-character

All verified community nodes use standalone repos (not monorepos), so the `repository.directory` field may also need to be communicated to the n8n team separately.

## Verification
- `npm pack --dry-run` produces identical file lists before and after the `dist/**` → `dist` change (7 files, 37.2 kB)
- `n8n-node cloud-support` → ✅ ENABLED

## Test plan
- [x] `n8n-node cloud-support` → ✅ ENABLED
- [x] `bun run check` → passes (biome + types + package format)
- [x] `bun test` → 39 tests passing
- [x] `@n8n/scan-community-package` local scan → passes clean