### PR TITLE
fix(mcp): fix MCP registry publish and add npm propagation check

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -53,6 +53,26 @@ jobs:
           GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
           VERSION: ${{ needs.publish.outputs.version }}
         run: |
+          echo "⏳ Waiting for @youdotcom-oss/mcp@${VERSION} to be available on npm..."
+          npm_attempts=0
+          npm_max=24  # Up to 24 checks (4min total)
+          npm_interval=10  # Check every 10 seconds
+
+          while [ $npm_attempts -lt $npm_max ]; do
+            npm_attempts=$((npm_attempts + 1))
+            if npm view "@youdotcom-oss/mcp@${VERSION}" version >/dev/null 2>&1; then
+              echo "✅ @youdotcom-oss/mcp@${VERSION} is available on npm"
+              break
+            fi
+            echo "Not available yet, retrying in ${npm_interval}s... (${npm_attempts}/${npm_max})"
+            sleep $npm_interval
+          done
+
+          if [ $npm_attempts -ge $npm_max ]; then
+            echo "⚠️ @youdotcom-oss/mcp@${VERSION} not found on npm after $((npm_max * npm_interval))s"
+            exit 1
+          fi
+
           echo "⏳ Waiting for version update to complete on ${{ secrets.DEPLOYMENT_REPO }}..."
           echo "Looking for release: v${VERSION}"
 

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -48,7 +48,7 @@ jobs:
     needs: [publish, update-remote-version]
     runs-on: ubuntu-latest
     steps:
-      - name: Wait for remote version update to complete
+      - name: Wait for npm propagation and remote version update
         env:
           GH_TOKEN: ${{ secrets.RELEASE_ADMIN_TOKEN }}
           VERSION: ${{ needs.publish.outputs.version }}

--- a/packages/mcp/server.json
+++ b/packages/mcp/server.json
@@ -39,7 +39,7 @@
           "description": "Remote MCP server URL (defaults to https://api.you.com/mcp)",
           "isRequired": false,
           "isSecret": false,
-          "format": "uri"
+          "format": "string"
         }
       ]
     }


### PR DESCRIPTION
## Summary
- Fix MCP Registry publish failure by changing `server.json` env var format from `"uri"` to `"string"` (registry only accepts `string`, `number`, `boolean`, `filepath`)
- Replace blind deployment with npm availability polling — checks every 10s (up to 4min) before triggering production deployment

## Context
Fixes failure in https://github.com/youdotcom-oss/dx-toolkit/actions/runs/23813808688/job/69408362607

## Test plan
- [ ] Trigger publish workflow and verify MCP Registry publish succeeds
- [ ] Verify npm polling completes before production deployment starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)