### PR TITLE
fix(ci): prevent shell injection in droid review workflow

### DIFF
--- a/.github/workflows/droid-review.yml
+++ b/.github/workflows/droid-review.yml
@@ -28,21 +28,23 @@ jobs:
         id: check_internal
         if: github.event_name == 'pull_request'
         run: |
-          RESPONSE=$(gh api repos/${{ github.repository }}/collaborators/${{ github.event.pull_request.user.login }}/permission 2>/dev/null || echo '{"permission":"none"}')
+          RESPONSE=$(gh api "repos/$REPOSITORY/collaborators/$PR_AUTHOR/permission" 2>/dev/null || echo '{"permission":"none"}')
           PERMISSION=$(echo "$RESPONSE" | jq -r '.permission')
           echo "Author permission: $PERMISSION"
 
           if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "maintain" && "$PERMISSION" != "write" ]]; then
             echo "Skipping auto-review for external contributor (permission: $PERMISSION)"
             echo "Use 'Actions > Droid Auto Review > Run workflow' to manually trigger review"
-            echo "is_internal=false" >> $GITHUB_OUTPUT
+            echo "is_internal=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           echo "Author is internal contributor, proceeding with review"
-          echo "is_internal=true" >> $GITHUB_OUTPUT
+          echo "is_internal=true" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPOSITORY: ${{ github.repository }}
 
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -61,9 +63,10 @@ jobs:
 
       - name: Checkout PR branch
         if: github.event_name == 'workflow_dispatch'
-        run: gh pr checkout ${{ inputs.pr_number }}
+        run: gh pr checkout "$PR_NUMBER"
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
 
       - name: Install Droid CLI
         if: github.event_name == 'workflow_dispatch'
@@ -74,7 +77,9 @@ jobs:
       - name: Run Droid Review (external)
         if: github.event_name == 'workflow_dispatch'
         run: |
-          droid exec --auto high "/review ${{ github.repository }}/pull/${{ inputs.pr_number }}"
+          droid exec --auto high "/review $REPOSITORY/pull/$PR_NUMBER"
         env:
           FACTORY_API_KEY: ${{ secrets.FACTORY_API_KEY }}
           GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
## Summary
- move GitHub context and workflow inputs out of shell interpolation in `droid-review.yml`
- use step-scoped environment variables for PR number, repository, and PR author in shell commands
- keep the workflow behavior unchanged while removing the Semgrep-blocked pattern

## Validation
- `actionlint .github/workflows/droid-review.yml`
- `git diff --check`

## Context
Fixes the Semgrep failure from Actions run `25890656747`, job `76092834137`, which reported `yaml.github-actions.security.run-shell-injection.run-shell-injection` in `.github/workflows/droid-review.yml`.