### PR TITLE
ci: upgrade actions/checkout@v4 to v5 across workflows

### DIFF
--- a/.github/workflows/_publish-package.yml
+++ b/.github/workflows/_publish-package.yml
@@ -81,7 +81,7 @@ jobs:
 
           echo "✓ Input validation passed"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.PUBLISH_TOKEN }}
 
@@ -371,12 +371,12 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
       - name: Setup Node.js (for NPM OIDC)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "lts/*"
           registry-url: https://registry.npmjs.org
@@ -419,7 +419,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.PUBLISH_TOKEN }}
@@ -522,7 +522,7 @@ jobs:
     outputs:
       release_notes: ${{ steps.release.outputs.release_notes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
@@ -564,7 +564,7 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Create dependency update issue
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -39,7 +39,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
           token: ${{ secrets.PUBLISH_TOKEN }}

--- a/.github/workflows/semgrep-ci.yml
+++ b/.github/workflows/semgrep-ci.yml
@@ -18,5 +18,5 @@ jobs:
       image: semgrep/semgrep
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: semgrep ci


### PR DESCRIPTION
Upgrades all remaining `actions/checkout@v4` references to `v5` to resolve the Node.js 20 deprecation warnings flagged by Semgrep CI.

Semgrep run [#25890656747](https://github.com/youdotcom-oss/dx-toolkit/actions/runs/25890656747) annotated that Node.js 20 actions will be removed from GitHub runners after 2026-09-16. The shell-injection findings in `droid-review.yml` were already fixed in #83 (b4595bc); this PR cleans up the remaining deprecation warnings.

**Files updated**
- `.github/workflows/semgrep-ci.yml`
- `.github/workflows/ci.yml`
- `.github/workflows/publish-mcp.yml`
- `.github/workflows/_publish-package.yml` (5 instances)