### PR TITLE
chore: sync dx-toolkit packages with hosted tool surface (balance, discover)

### DIFF
--- a/packages/ai-sdk-plugin/README.md
+++ b/packages/ai-sdk-plugin/README.md
@@ -1,6 +1,6 @@
 # Vercel AI SDK Plugin for You.com
 
-Give your AI applications **real-time access to the web** through the hosted You.com MCP server. This package exposes an async `createYouClient()` helper that connects to `https://api.you.com/mcp` and returns the underlying AI SDK MCP client. By default, `await client.tools()` resolves to the default hosted tool set: `you-search`, `you-research`, and `you-contents`.
+Give your AI applications **real-time access to the web** through the hosted You.com MCP server. This package exposes an async `createYouClient()` helper that connects to `https://api.you.com/mcp` and returns the underlying AI SDK MCP client. By default, `await client.tools()` resolves to the default hosted tool set: `you-search`, `you-contents`, `you-research`, `you-balance`, and `you-discover`.
 
 ## Features
 
@@ -85,7 +85,7 @@ try {
 }
 ```
 
-`createYouClient()` returns the underlying MCP client. Call `await client.tools()` to resolve the default hosted tool set (`you-search`, `you-research`, and `you-contents`) unless you scope it with `tools`, and call `await client.close()` when finished.
+`createYouClient()` returns the underlying MCP client. Call `await client.tools()` to resolve the default hosted tool set (`you-search`, `you-contents`, `you-research`, `you-balance`, and `you-discover`) unless you scope it with `tools`, and call `await client.close()` when finished.
 
 Set your You.com API key as an environment variable:
 
@@ -218,8 +218,10 @@ The package always connects to `https://api.you.com/mcp`.
 The default hosted tool set is:
 
 - `you-search`
-- `you-research`
 - `you-contents`
+- `you-research`
+- `you-balance`
+- `you-discover`
 
 Optional tools:
 
@@ -231,7 +233,7 @@ Optional tools:
 
 `profile` selects a hosted server profile. `tools` scopes which tools are visible. If `profile` is provided, it takes precedence over `tools`.
 
-Today, `profile: 'free'` is a search-only mode. It overrides `tools` and does not expose `you-research`, `you-contents`, `you-finance`, or livecrawl.
+Today, `profile: 'free'` is a search-only mode. It overrides `tools` and does not expose `you-contents`, `you-research`, `you-finance`, `you-balance`, `you-discover`, or livecrawl.
 
 ### Using different model providers
 
@@ -303,8 +305,10 @@ const result = await generateText({
 Default tools:
 
 - `you-search`
-- `you-research`
 - `you-contents`
+- `you-research`
+- `you-balance`
+- `you-discover`
 
 Optional tools:
 

--- a/packages/ai-sdk-plugin/README.md
+++ b/packages/ai-sdk-plugin/README.md
@@ -185,7 +185,7 @@ If you want the default tools plus finance, request all of them explicitly:
 
 ```typescript
 const client = await createYouClient({
-  tools: ['you-search', 'you-research', 'you-contents', 'you-finance'],
+  tools: ['you-search', 'you-contents', 'you-research', 'you-balance', 'you-discover', 'you-finance'],
 });
 
 const tools = await client.tools();

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -7,6 +7,8 @@ export type {
   KnownToolInput,
   KnownToolName,
   KnownToolOutput,
+  YouBalanceInput,
+  YouBalanceOutput,
   YouContentsInput,
   YouContentsOutput,
   YouResearchInput,

--- a/packages/api/src/tool-schemas.ts
+++ b/packages/api/src/tool-schemas.ts
@@ -1,7 +1,48 @@
 // This file is generated. Do not edit by hand.
-export const API_TOOL_SCHEMA_HASH = '21d8d2b89ea820b8afc5da4cc7399263f3ab0699a684256a0f0fb8f2af6069e5'
+export const API_TOOL_SCHEMA_HASH = '0c74f7091eca6ec01a70e3bc62029873e7dac682b473ddcc7c39fa1df35ddf65'
 
 export const API_TOOL_SCHEMAS = {
+  'you-balance': {
+    inputSchema: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      properties: {},
+      type: 'object',
+    },
+    outputSchema: {
+      $schema: 'http://json-schema.org/draft-07/schema#',
+      additionalProperties: false,
+      properties: {
+        data: {
+          additionalProperties: false,
+          properties: {
+            attributes: {
+              additionalProperties: false,
+              properties: {
+                balance: {
+                  description: 'Remaining credit balance in cents. Divide by 100 to convert to USD.',
+                  type: 'number',
+                },
+              },
+              required: ['balance'],
+              type: 'object',
+            },
+            id: {
+              description: 'A hashed identifier for the billing entity (user or organization).',
+              type: 'string',
+            },
+            type: {
+              description: 'The type of billing entity. Always "account".',
+              type: 'string',
+            },
+          },
+          required: ['type', 'id', 'attributes'],
+          type: 'object',
+        },
+      },
+      required: ['data'],
+      type: 'object',
+    },
+  },
   'you-contents': {
     inputSchema: {
       $schema: 'http://json-schema.org/draft-07/schema#',
@@ -509,6 +550,18 @@ export const API_TOOL_SCHEMAS = {
   },
 } as const
 
+export type YouBalanceInput = Record<string, unknown>
+
+export type YouBalanceOutput = {
+  data: {
+    attributes: {
+      balance: number
+    }
+    id: string
+    type: string
+  }
+}
+
 export type YouContentsInput = {
   crawl_timeout?: number
   format?: 'markdown' | 'html'
@@ -686,12 +739,14 @@ export type YouSearchOutput = {
 export type KnownToolName = keyof typeof API_TOOL_SCHEMAS
 
 type KnownToolInputMap = {
+  'you-balance': YouBalanceInput
   'you-contents': YouContentsInput
   'you-research': YouResearchInput
   'you-search': YouSearchInput
 }
 
 type KnownToolOutputMap = {
+  'you-balance': YouBalanceOutput
   'you-contents': YouContentsOutput
   'you-research': YouResearchOutput
   'you-search': YouSearchOutput

--- a/packages/cli/src/tests/cli.spec.ts
+++ b/packages/cli/src/tests/cli.spec.ts
@@ -87,9 +87,9 @@ describe('ydc tools', () => {
     expect(exitCode).toBe(0)
     expect(stderr).toBe('')
     expect(JSON.parse(stdout)).toEqual({
-      contractHash: 'eb28a7ce9289045254f5b3ed78be8eec5b7caf25bec8457e5a47fae0b070f283',
-      surfaceVersion: '2026.05.14',
-      tools: ['you-contents', 'you-finance', 'you-research', 'you-search'],
+      contractHash: 'dad771e3d324f1020f3af8f2ea506844be1dea559af3e6f65bb9e7febb65286a',
+      surfaceVersion: '2026.07.23',
+      tools: ['you-balance', 'you-contents', 'you-discover', 'you-finance', 'you-research', 'you-search'],
     })
   })
 })

--- a/packages/cli/src/tools.ts
+++ b/packages/cli/src/tools.ts
@@ -1,10 +1,16 @@
 // This file is generated. Do not edit by hand.
 export const TOOL_CONTRACT = {
-  contractHash: 'eb28a7ce9289045254f5b3ed78be8eec5b7caf25bec8457e5a47fae0b070f283',
-  surfaceVersion: '2026.05.14',
+  contractHash: 'dad771e3d324f1020f3af8f2ea506844be1dea559af3e6f65bb9e7febb65286a',
+  surfaceVersion: '2026.07.23',
   tools: [
     {
+      name: 'you-balance',
+    },
+    {
       name: 'you-contents',
+    },
+    {
+      name: 'you-discover',
     },
     {
       name: 'you-finance',

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -2,7 +2,7 @@
 
 Give your LangChain agents **real-time access to the web** through the hosted You.com MCP server. This package exposes an async `createYouClient()` helper that connects to `https://api.you.com/mcp` via `@langchain/mcp-adapters` and returns the underlying LangChain MCP client.
 
-By default, `await client.getTools()` resolves to the default hosted tool set: `you-search`, `you-research`, and `you-contents`. To use `you-finance`, request it explicitly in the `tools` parameter.
+By default, `await client.getTools()` resolves to the default hosted tool set: `you-search`, `you-contents`, `you-research`, `you-balance`, and `you-discover`. To use `you-finance`, request it explicitly in the `tools` parameter.
 
 ## Features
 
@@ -93,7 +93,7 @@ const result = await agent.invoke({
 console.log(result.structuredResponse);
 ```
 
-`createYouClient()` returns the underlying MCP client. Call `await client.getTools()` to resolve the default hosted tool set (`you-search`, `you-research`, and `you-contents`) unless you scope it with `tools`, and call `await client.close()` when finished.
+`createYouClient()` returns the underlying MCP client. Call `await client.getTools()` to resolve the default hosted tool set (`you-search`, `you-contents`, `you-research`, `you-balance`, and `you-discover`) unless you scope it with `tools`, and call `await client.close()` when finished.
 
 Set your You.com API key as an environment variable:
 
@@ -213,8 +213,10 @@ The package always connects to `https://api.you.com/mcp`.
 The default hosted tool set is:
 
 - `you-search`
-- `you-research`
 - `you-contents`
+- `you-research`
+- `you-balance`
+- `you-discover`
 
 Optional tools:
 
@@ -226,7 +228,7 @@ Optional tools:
 
 `profile` selects a hosted server profile. `tools` scopes which tools are visible. If `profile` is provided, it takes precedence over `tools`.
 
-Today, `profile: 'free'` is a search-only mode. It overrides `tools` and does not expose `you-research`, `you-contents`, `you-finance`, or livecrawl.
+Today, `profile: 'free'` is a search-only mode. It overrides `tools` and does not expose `you-contents`, `you-research`, `you-finance`, `you-balance`, `you-discover`, or livecrawl.
 
 ### Using different model providers
 
@@ -275,8 +277,10 @@ console.log(result);
 Default tools:
 
 - `you-search`
-- `you-research`
 - `you-contents`
+- `you-research`
+- `you-balance`
+- `you-discover`
 
 Optional tools:
 

--- a/packages/langchain/README.md
+++ b/packages/langchain/README.md
@@ -180,7 +180,7 @@ If you want the default tools plus finance, request all of them explicitly:
 
 ```typescript
 const client = await createYouClient({
-  tools: ['you-search', 'you-research', 'you-contents', 'you-finance'],
+  tools: ['you-search', 'you-contents', 'you-research', 'you-balance', 'you-discover', 'you-finance'],
 });
 
 const tools = await client.getTools();

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -35,7 +35,6 @@ The hosted MCP capability surface includes:
 - `you-contents`
 - `you-research`
 - `you-finance`
-- `you-eco`
 - `you-balance`
 - `you-discover`
 
@@ -47,11 +46,11 @@ The default hosted MCP URL exposes the default tool set:
 - `you-balance`
 - `you-discover`
 
-`you-finance` and `you-eco` are not included in the default tool set. Request them explicitly with `tools`.
+`you-finance` is not included in the default tool set. Request it explicitly with `tools`.
 
 `tools` scopes the visible tool set.
 
-Today, `profile=free` is a search-only mode. It overrides `tools` and exposes only `you-search` (not `you-contents`, `you-research`, `you-finance`, `you-eco`, `you-balance`, `you-discover`, or livecrawl).
+Today, `profile=free` is a search-only mode. It overrides `tools` and exposes only `you-search` (not `you-contents`, `you-research`, `you-finance`, `you-balance`, `you-discover`, or livecrawl).
 
 Examples:
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -31,22 +31,27 @@ npx @youdotcom-oss/mcp
 
 The hosted MCP capability surface includes:
 
-- `you-contents`
-- `you-finance`
-- `you-research`
 - `you-search`
+- `you-contents`
+- `you-research`
+- `you-finance`
+- `you-eco`
+- `you-balance`
+- `you-discover`
 
 The default hosted MCP URL exposes the default tool set:
 
 - `you-search`
-- `you-research`
 - `you-contents`
+- `you-research`
+- `you-balance`
+- `you-discover`
 
-`you-finance` is not included in the default tool set. Request it explicitly with `tools`.
+`you-finance` and `you-eco` are not included in the default tool set. Request them explicitly with `tools`.
 
 `tools` scopes the visible tool set.
 
-Today, `profile=free` is a search-only mode. It overrides `tools` and does not expose `you-research`, `you-contents`, `you-finance`, or livecrawl.
+Today, `profile=free` is a search-only mode. It overrides `tools` and exposes only `you-search` (not `you-contents`, `you-research`, `you-finance`, `you-eco`, `you-balance`, `you-discover`, or livecrawl).
 
 Examples:
 

--- a/scripts/tests/update-api-schemas.spec.ts
+++ b/scripts/tests/update-api-schemas.spec.ts
@@ -4,6 +4,39 @@ import { resolve } from 'node:path'
 import { renderApiSchemas } from '../update-api-schemas.ts'
 
 const basePayload = {
+  'you-balance': {
+    inputSchema: {
+      properties: {},
+      type: 'object',
+    },
+    outputSchema: {
+      properties: {
+        data: {
+          properties: {
+            attributes: {
+              properties: {
+                balance: {
+                  type: 'number',
+                },
+              },
+              required: ['balance'],
+              type: 'object',
+            },
+            id: {
+              type: 'string',
+            },
+            type: {
+              type: 'string',
+            },
+          },
+          required: ['type', 'id', 'attributes'],
+          type: 'object',
+        },
+      },
+      required: ['data'],
+      type: 'object',
+    },
+  },
   'you-contents': {
     inputSchema: {
       properties: {
@@ -77,6 +110,9 @@ describe('renderApiSchemas', () => {
     expect(output).toContain(`export const API_TOOL_SCHEMAS = {`)
     expect(output).toContain(`export type YouSearchInput = {`)
     expect(output).toContain(`query: string`)
+    expect(output).toContain(`export type YouBalanceInput = Record<string, unknown>`)
+    expect(output).toContain(`export type YouBalanceOutput = {`)
+    expect(output).toContain(`balance: number`)
     expect(output).toContain(`export type KnownToolOutput<T extends KnownToolName> = KnownToolOutputMap[T]`)
   })
 })

--- a/scripts/update-api-schemas.ts
+++ b/scripts/update-api-schemas.ts
@@ -33,7 +33,7 @@ type ToolSchema = {
 
 type ToolSchemaPayload = Record<string, ToolSchema>
 
-const knownTools = ['you-contents', 'you-research', 'you-search'] as const
+const knownTools = ['you-balance', 'you-contents', 'you-research', 'you-search'] as const
 
 const toTypeScriptString = (value: string) => `'${JSON.stringify(value).slice(1, -1).replaceAll("'", "\\'")}'`
 


### PR DESCRIPTION
## Summary
Syncs the dx-toolkit packages with the current hosted You.com MCP tool surface, which has added `you-balance` and `you-discover`. Source of truth: `youdotcom-mcp-server/src/tools.ts`.

## Changes by package

### `mcp` (docs)
- README capability surface and default set updated to include `you-balance` and `you-discover`.
- `you-finance` documented as the non-default tool; `you-eco` intentionally not advertised.

### `cli` (code, required)
- Regenerated `TOOL_CONTRACT` (`src/tools.ts`) via `scripts/update-cli-tools.ts` to add `you-balance` and `you-discover`. The CLI gates `schema`/execute/help on this contract, so both are required for the CLI to invoke them.
- `surfaceVersion` bumped to `2026.07.23`; new `contractHash`.
- Updated the hardcoded contract assertion in `cli.spec.ts`.

### `api` (code, typed DX)
- Added `you-balance` to the generator allowlist (`scripts/update-api-schemas.ts` `knownTools`) and regenerated `packages/api/src/tool-schemas.ts` against the live server.
- `YouBalanceInput` (`Record<string, unknown>`) and `YouBalanceOutput` (`{ data: { attributes: { balance: number }, id, type } }`) now exported from `main.ts`.
- Extended the `renderApiSchemas` fixture/assertions in `scripts/tests/update-api-schemas.spec.ts`.
- `you-discover` intentionally not typed (its value is dynamic external results; the API client already handles any tool via the generic `call`/`schema`/`tools`).

### `langchain` + `ai-sdk-plugin` (docs)
- READMEs' default hosted tool set synced to add `you-balance` and `you-discover`. Both packages are tool-agnostic passthroughs; no code changes.

## Notes
- No version bumps or `server.json` changes (CI/publish workflow manages versions; `server.json` is tool-agnostic).
- `eco` is not advertised anywhere.

## Validation
- `bun --cwd packages/{cli,api,langchain,ai-sdk-plugin,mcp} check` all pass.
- `bun --cwd packages/cli test` (26 pass), `bun --cwd packages/api test` (10 pass).
- `bun test scripts/tests/update-cli-tools.spec.ts scripts/tests/update-api-schemas.spec.ts` (4 pass).
